### PR TITLE
feat: customizable `tempDir` option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,15 @@ type File = {
 	content: string;
 };
 
+export type CreateFixtureOptions = {
+
+	/**
+	 * The temporary directory to create the fixtures in.
+	 * Defaults to `os.tmpdir()`.
+	 */
+	tempDir?: string;
+};
+
 const flattenFileTree = (
 	fileTree: FileTree,
 	pathPrefix: string,
@@ -100,8 +109,13 @@ const flattenFileTree = (
 
 export const createFixture = async (
 	source?: string | FileTree,
+	options?: CreateFixtureOptions,
 ) => {
-	const fixturePath = path.join(temporaryDirectory, `${directoryNamespace}-${getId()}/`);
+	const resolvedTemporaryDirectory = options?.tempDir
+		? path.resolve(options.tempDir)
+		: temporaryDirectory;
+
+	const fixturePath = path.join(resolvedTemporaryDirectory, `${directoryNamespace}-${getId()}/`);
 
 	await fs.mkdir(fixturePath, {
 		recursive: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { FsFixture } from './fs-fixture.js';
 import {
-	temporaryDirectory,
+	osTemporaryDirectory,
 	directoryNamespace,
 	getId,
 } from './utils';
@@ -113,7 +113,7 @@ export const createFixture = async (
 ) => {
 	const resolvedTemporaryDirectory = options?.tempDir
 		? path.resolve(options.tempDir)
-		: temporaryDirectory;
+		: osTemporaryDirectory;
 
 	const fixturePath = path.join(resolvedTemporaryDirectory, `${directoryNamespace}-${getId()}/`);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 
-export const temporaryDirectory = fs.realpathSync(os.tmpdir());
+export const osTemporaryDirectory = fs.realpathSync(os.tmpdir());
 export const directoryNamespace = `fs-fixture-${Date.now()}`;
 
 let id = 0;

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -133,12 +133,7 @@ describe('fs-fixture', ({ test }) => {
 	});
 
 	test('custom temporary directory', async () => {
-		const customTemporaryDirectory = path.join(await fs.realpath(os.tmpdir()), 'custom-fs-fixture');
-		// Remove if exists from previous run
-		await fs.rm(customTemporaryDirectory, {
-			recursive: true,
-			force: true,
-		});
+		const customTemporaryDirectory = path.join(await fs.realpath(os.tmpdir()), 'custom-dir-' + Date.now());
 
 		const fixture = await createFixture({}, {
 			tempDir: customTemporaryDirectory,
@@ -147,7 +142,6 @@ describe('fs-fixture', ({ test }) => {
 		expect(await fixture.exists()).toBe(true);
 		expect(fixture.getPath().startsWith(customTemporaryDirectory)).toBe(true);
 
-		// rm entire tempDir (includes fixture)
 		await fs.rm(customTemporaryDirectory, {
 			recursive: true,
 			force: true,

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,4 +1,5 @@
 import fs from 'fs/promises';
+import os from 'os';
 import path from 'path';
 import { describe, expect } from 'manten';
 import { createFixture, type FsFixture } from '#fs-fixture';
@@ -129,5 +130,27 @@ describe('fs-fixture', ({ test }) => {
 			expect(await exists(fixturePath)).toBe(true);
 		}
 		expect(await exists(fixturePath)).toBe(false);
+	});
+
+	test('custom temporary directory', async () => {
+		const customTemporaryDirectory = path.join(await fs.realpath(os.tmpdir()), 'custom-fs-fixture');
+		// Remove if exists from previous run
+		await fs.rm(customTemporaryDirectory, {
+			recursive: true,
+			force: true,
+		});
+
+		const fixture = await createFixture({}, {
+			tempDir: customTemporaryDirectory,
+		});
+
+		expect(await fixture.exists()).toBe(true);
+		expect(fixture.getPath().startsWith(customTemporaryDirectory)).toBe(true);
+
+		// rm entire tempDir (includes fixture)
+		await fs.rm(customTemporaryDirectory, {
+			recursive: true,
+			force: true,
+		});
 	});
 });


### PR DESCRIPTION
Allow setting a custom temporary directory option. My usecase was that the fixtures needed to access certain dependencies so placing them in a specific gitignored directory in the project allows it (not always the best kind of test I guess).

Another option is to specify the fixture directory directly. I'm fine either way depending on which you prefer.