### PR TITLE
fix: `cp` destination to be optional

### DIFF
--- a/src/fs-fixture.ts
+++ b/src/fs-fixture.ts
@@ -59,10 +59,12 @@ export class FsFixture {
 		destinationSubpath?: string,
 		options?: CopyOptions,
 	) {
-		if (destinationSubpath?.endsWith(path.sep)) {
+		if (!destinationSubpath) {
+			destinationSubpath = path.basename(sourcePath);
+		} else if (destinationSubpath.endsWith(path.sep)) {
 			destinationSubpath += path.basename(sourcePath);
 		}
-		destinationSubpath ??= path.basename(sourcePath);
+
 		return fs.cp(
 			sourcePath,
 			this.getPath(destinationSubpath),

--- a/src/fs-fixture.ts
+++ b/src/fs-fixture.ts
@@ -56,9 +56,13 @@ export class FsFixture {
 	*/
 	cp(
 		sourcePath: string,
-		destinationSubpath: string,
+		destinationSubpath?: string,
 		options?: CopyOptions,
 	) {
+		if (destinationSubpath?.endsWith(path.sep)) {
+			destinationSubpath += path.basename(sourcePath);
+		}
+		destinationSubpath ??= path.basename(sourcePath);
 		return fs.cp(
 			sourcePath,
 			this.getPath(destinationSubpath),

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -80,6 +80,12 @@ describe('fs-fixture', ({ test }) => {
 		await fixture.cp(filePathA, 'directory/a-copy');
 		expect(await fixture.readFile('directory/a-copy', 'utf8')).toBe('a');
 
+		await fixture.cp(filePathA);
+		expect(await fixture.readFile('a', 'utf8')).toBe('a');
+
+		await fixture.cp(filePathA, 'directory2/');
+		expect(await fixture.readFile('directory2/a', 'utf8')).toBe('a');
+
 		// rm file
 		await fixture.rm('directory/a');
 


### PR DESCRIPTION
The README suggests the second param is optional (`?:`), but currently it throws an error without one…